### PR TITLE
Work around gv_fetchmeth_pvn bug in older perls

### DIFF
--- a/lib/SUPER.pm
+++ b/lib/SUPER.pm
@@ -42,6 +42,19 @@ use Carp;
 use Scalar::Util 'blessed';
 use Sub::Identify ();
 
+BEGIN {
+    # Due to a perl bug (fixed in v5.17.4, commit 3c104e59), if SUPER.pm is
+    # loaded, perl can no longer find methods on parent when:
+    # 1) the invocant is "main" (or isa "main")
+    # 2) using the SUPER pseudo-class syntax (i.e. "main"->SUPER::...)
+    # We work around that bug by handling ->SUPER::... ourselves.
+    if ($] < 5.017004)
+    {
+        no strict 'refs';
+        *{"SUPER::AUTOLOAD"} = \&UNIVERSAL::SUPER;
+    }
+}
+
 # no need to use Exporter
 sub import
 {

--- a/t/pseudoclass_syntax.t
+++ b/t/pseudoclass_syntax.t
@@ -1,0 +1,44 @@
+#!perl
+use strict;
+use warnings;
+
+# Test that the pseudo-class syntax still works despite having SUPER.pm loaded.
+
+use SUPER;
+use Test::More tests => 6;
+
+package MyBase;
+
+Test::More->import();
+
+sub new { bless {}, shift }
+
+sub foo
+{
+    my $self = shift;
+    if (ref $self) {
+        isa_ok( $self, "main" );
+    }
+    else {
+        is( $self, "main" );    # isa_ok($str) doesn't work on older Test::More
+    }
+    is( $_[0], 123, "Arguments passed OK" );
+}
+
+package main;
+
+Test::More->import();
+@main::ISA = 'MyBase';
+
+sub foo
+{
+    my $self = shift;
+    $self->SUPER::foo(@_);
+}
+
+eval { main->foo(123) };
+is( $@, '', 'Can use pseudo-class main->SUPER::method syntax' );
+
+my $m = main->new();
+eval { $m->foo(123) };
+is( $@, '', 'Can use pseudo-class $isa_main->SUPER::method syntax' );


### PR DESCRIPTION
So... this is a long shot but how interested are you in adding a workaround for an old perl bug? Well, if that interests you, here's a patch for your consideration.

This allows `main->SUPER::...` to work when SUPER.pm is loaded, even on older perls. The problem being worked around here was fixed in Perl/perl5@3c104e59 and improved in Perl/perl5@aae43805, released with perl 5.17.4.

